### PR TITLE
API changed: correct errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ const RarbgApi = require('rarbg')
 // Create a new instance of the module.
 const rarbg = new RarbgApi()
 ```
+You can pass the configuration by the constructor
+```javascript
+const rarbg = new RarbgApi({
+  host: 'torrentapi.org',
+  path: '/pubapi_v2.php?',
+  app_id: 'my_application',
+  user_agent: 'My Application 0.0.1'
+})
+```
 
 ### Methods
 

--- a/index.js
+++ b/index.js
@@ -5,11 +5,14 @@ const moment = require('moment')
 const { stringify } = require('querystring')
 
 module.exports = class RarbgApi {
-  constructor () {
-    this.config = {
+  constructor (config) {
+    this.config = Object.assign({
       host: 'torrentapi.org',
-      path: '/pubapi_v2.php?'
-    }
+      path: '/pubapi_v2.php?',
+      app_id: 'rarbg_npm',
+      user_agent: 'https://github.com/grantholle/rarbg'
+    }, config)
+
     this.categories = {
       XXX: 4,
       MOVIES_XVID: 14,
@@ -115,9 +118,13 @@ module.exports = class RarbgApi {
 
   sendRequest (query) {
     return new Promise((resolve, reject) => {
+      query.app_id = this.config.app_id
       const req = {
         host: this.config.host,
-        path: this.config.path + stringify(query)
+        path: this.config.path + stringify(query),
+        headers: {
+          'User-Agent': this.config.user_agent
+        }
       }
 
       https.get(req, res => {


### PR DESCRIPTION
API changed: https://torrentapi.org/apidocs_v2.txt
Now, we have to add `app_id` to the request and send the `User-Agent` to the server