### PR TITLE
Fix config being mandatory in constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ interface RequestParams {
 }
 
 declare class Rarbg {
-  constructor (config: ConfigSettings)
+  constructor (config?: ConfigSettings)
   search (params: RequestParams)
   list (params?: RequestParams)
 


### PR DESCRIPTION
The `config` object is actually not mandatory as it has default values, this PR fixes the types definitions.